### PR TITLE
Term titles

### DIFF
--- a/lynx.cfg
+++ b/lynx.cfg
@@ -3635,7 +3635,7 @@ COLOR:6:brightred:black
 # If your terminal emulator supports that escape code,
 # you can set this to TRUE.
 # This is the same as the command-line "-update_term_title" option.
-#UPDATE_TERM_TITLE:TRUE
+#UPDATE_TERM_TITLE:FALSE
 
 .h1 External Programs
 

--- a/lynx.cfg
+++ b/lynx.cfg
@@ -3630,6 +3630,12 @@ COLOR:6:brightred:black
 # This is the same as the command-line "-notitle" option.
 #NO_TITLE:FALSE
 
+.h2 UPDATE_TERM_TITLE
+# Enables updating the title in terminal emulators.
+# If your terminal emulator supports that escape code,
+# you can set this to TRUE.
+#UPDATE_TERM_TITLE:TRUE
+
 .h1 External Programs
 
 .h2 SYSLOG_REQUESTED_URLS

--- a/lynx.cfg
+++ b/lynx.cfg
@@ -3634,6 +3634,7 @@ COLOR:6:brightred:black
 # Enables updating the title in terminal emulators.
 # If your terminal emulator supports that escape code,
 # you can set this to TRUE.
+# This is the same as the command-line "-update_term_title" option.
 #UPDATE_TERM_TITLE:TRUE
 
 .h1 External Programs

--- a/lynx.hlp
+++ b/lynx.hlp
@@ -803,6 +803,11 @@
               check  for duplicate link numbers in each page and corresponding
               lists, and reuse the original link number.
 
+       -update_term_title
+               enables updating the title in terminal emulators.  Use only if
+               your terminal emulator supports that escape code.  Has no effect
+               when used with -notitle.
+
        -use_mouse
               turn on mouse support, if available.  Clicking  the  left  mouse
               button  on a link traverses it.  Clicking the right mouse button

--- a/lynx.man
+++ b/lynx.man
@@ -960,6 +960,11 @@ a simple menu.
 Mouse clicks may only work reliably while \fILynx\fP is
 idle waiting for input.
 .TP
+.B \-update_term_title
+enables updating the title in terminal emulators.
+Use only if your terminal emulator supports that escape code.
+Has no effect when used with -notitle.
+.TP
 .B \-useragent=Name
 set alternate \fILynx\fP User-Agent header.
 .TP

--- a/lynx_help/Lynx_users_guide.html
+++ b/lynx_help/Lynx_users_guide.html
@@ -5259,6 +5259,16 @@ lynx -source ./ &gt;foo.html
         </dd>
 
         <dt>
+        <code><strong>-update_term_title</strong></code>
+        </dt>
+
+        <dd>
+          <p>enables updating the title in terminal emulators. Use
+          only if your terminal emulator supports that escape code.
+          Has no effect when used with -notitle.</p>
+        </dd>
+
+        <dt>
         <code><strong>-useragent=</strong><em>STRING</em></code>
         </dt>
 

--- a/src/GridText.c
+++ b/src/GridText.c
@@ -1735,8 +1735,10 @@ static void display_title(HText *text)
     }
 
     /* Update the terminal-emulator title */
-    fprintf(stdout, "\033]0;%s%sLynx\007", title, strlen(title) > 0 ? " - " : "");
-    fflush(stdout);
+    if (update_term_title) {
+        fprintf(stdout, "\033]0;%s%sLynx\007", title, strlen(title) > 0 ? " - " : "");
+        fflush(stdout);
+    }
 
     /*
      * Generate and display the title string, with page indicator

--- a/src/GridText.c
+++ b/src/GridText.c
@@ -1734,6 +1734,10 @@ static void display_title(HText *text)
 	percent[0] = '\0';
     }
 
+    /* Update the terminal-emulator title */
+    fprintf(stdout, "\033]0;%s%sLynx\007", title, strlen(title) > 0 ? " - " : "");
+    fflush(stdout);
+
     /*
      * Generate and display the title string, with page indicator
      * if appropriate, preceded by the toolbar token if appropriate,

--- a/src/LYGlobalDefs.h
+++ b/src/LYGlobalDefs.h
@@ -404,6 +404,7 @@ extern "C" {
     extern BOOLEAN no_margins;
     extern BOOLEAN no_pause;
     extern BOOLEAN no_title;
+    extern BOOLEAN update_term_title;
     extern BOOLEAN historical_comments;
     extern BOOLEAN html5_charsets;
     extern BOOLEAN minimal_comments;

--- a/src/LYMain.c
+++ b/src/LYMain.c
@@ -4011,6 +4011,10 @@ bug which treated '>' as a co-terminator for\ndouble-quotes and tags"
       "unique_urls",	4|TOGGLE_ARG,		unique_urls,
       "toggles use of unique-urls setting for -dump and -listonly options"
    ),
+   PARSE_SET(
+       "update_term_title", 4|SET_ARG, update_term_title,
+       "enables updating the title of terminal emulators"
+   ),
 #if defined(USE_MOUSE)
    PARSE_SET(
       "use_mouse",	4|SET_ARG,		LYUseMouse,

--- a/src/LYMain.c
+++ b/src/LYMain.c
@@ -409,6 +409,7 @@ BOOLEAN no_list = FALSE;
 BOOLEAN no_margins = FALSE;
 BOOLEAN no_pause = FALSE;
 BOOLEAN no_title = FALSE;
+BOOLEAN update_term_title = FALSE;
 BOOLEAN no_url_redirection = FALSE;	/* Don't follow URL redirections */
 BOOLEAN pseudo_inline_alts = MAKE_PSEUDO_ALTS_FOR_INLINES;
 BOOLEAN scan_for_buried_news_references = TRUE;

--- a/src/LYReadCFG.c
+++ b/src/LYReadCFG.c
@@ -1647,6 +1647,7 @@ static Config_Type Config_Table [] =
      PARSE_SET(RC_NO_REFERER_HEADER,    LYNoRefererHeader),
      PARSE_SET(RC_NO_TABLE_CENTER,      no_table_center),
      PARSE_SET(RC_NO_TITLE,             no_title),
+     PARSE_SET(RC_UPDATE_TERM_TITLE,    update_term_title),
      PARSE_FUN(RC_NONRESTARTING_SIGWINCH, nonrest_sigwinch_fun),
      PARSE_FUN(RC_OUTGOING_MAIL_CHARSET, outgoing_mail_charset_fun),
 #ifdef DISP_PARTIAL

--- a/src/LYrcFile.h
+++ b/src/LYrcFile.h
@@ -178,6 +178,7 @@
 #define RC_NO_REFERER_HEADER            "no_referer_header"
 #define RC_NO_TABLE_CENTER              "no_table_center"
 #define RC_NO_TITLE                     "no_title"
+#define RC_UPDATE_TERM_TITLE            "update_term_title"
 #define RC_NUMBER_FIELDS_ON_LEFT        "number_fields_on_left"
 #define RC_NUMBER_LINKS_ON_LEFT         "number_links_on_left"
 #define RC_OUTGOING_MAIL_CHARSET        "outgoing_mail_charset"


### PR DESCRIPTION
This is to allow Lynx to set the title-bar text in terminal emulators.  It's disabled by default, not only for backwards compatibility, but also because I don't know if there are terminal emulators that wouldn't support it and would send the escape sequence to stdout instead (it's ignored in the Linux console, but who knows about DOS, Windows, etc.).

I went with calling the option `UPDATE_TERM_TITLE`, but it could easily be changed to something else.  I considered something like `XTERM_TITLE` or `XTITLE`.  That's the route most other text programs go, but I decided against it for two reasons:
1. It works in terminal emulators other than xterm.
2. It works in terminal emulators in environments other than X.
(For example, it works fine in weston-terminal.)