### PR TITLE
Make 'src/HTML.h' atomic

### DIFF
--- a/src/HTML.h
+++ b/src/HTML.h
@@ -18,6 +18,8 @@
 #include <UCAux.h>
 #include <HTAnchor.h>
 #include <HTMLDTD.h>
+#include <HText.h>
+#include <HTStyle.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
I did an experiment with `clang-format -i *.c` on most of the Lynx sources. 
With a `SortIncludes:  true` in the `.clang-format`, this causes only compile error in `HTML.c`
due to `.h`-files not being in the expected order:
```c
In file included from src/HTML.c:24:
./src\HTML.h(57,2): error: unknown type name 'HTStyle'
        HTStyle *style;
        ^
./src\HTML.h(69,2): error: unknown type name 'HText'
        HText *text;
        ^
./src\HTML.h(136,2): error: unknown type name 'HTStyle'
        HTStyle *new_style;
        ^
./src\HTML.h(137,2): error: unknown type name 'HTStyle'
        HTStyle *old_style;
        ^
./src\HTML.h(212,12): error: unknown type name 'HTStyle'
    extern HTStyle *LYstyles(int style_number);
           ^
In file included from src/HTML.c:24:
./src\HTML.h(70,2): error: unknown type name 'HText'
        HText *text;
        ^
```

So adding the required  `.h`-files  to `src/HTM.h` fixed this problem.

*PS*. Maybe you could add an **Issue** button here on Github?